### PR TITLE
Fix Gitee release detail links and centralize release parsing

### DIFF
--- a/doc/.vitepress/theme/components/DownloadCard.vue
+++ b/doc/.vitepress/theme/components/DownloadCard.vue
@@ -10,6 +10,7 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { useData } from 'vitepress'
 import { renderMarkdown } from '../utils/renderMarkdown'
+import { resolveRepoMeta, transformReleases } from '../utils/releases'
 
 const props = defineProps({
   item: {
@@ -61,57 +62,6 @@ const normalizeBody = (body) => {
   return String(body).includes('<') ? body : renderMarkdown(body)
 }
 
-const resolveRepoMeta = (urlField) => {
-  if (!urlField) return null
-  const url = urlField.trim()
-  if (url.includes('gitee.com/')) {
-    const path = url.split('gitee.com/')[1].replace(/\/releases\/?$/, '').replace(/\/$/, '')
-    return { platform: 'gitee', apiUrl: `https://gitee.com/api/v5/repos/${path}/releases` }
-  }
-  if (url.includes('github.com/')) {
-    const path = url.split('github.com/')[1].replace(/\/releases\/?$/, '').replace(/\/$/, '')
-    return { platform: 'github', apiUrl: `https://api.github.com/repos/${path}/releases` }
-  }
-  return null
-}
-
-const transformReleases = (rawData, platform) => {
-  if (!Array.isArray(rawData)) return []
-
-  const normalizedRawData = platform === 'gitee' ? [...rawData].reverse() : rawData
-
-  return normalizedRawData.map(item => {
-    const rawAssets = item.assets || []
-    const filteredAssets = rawAssets.filter(a => {
-      const n = (a.name || '').toLowerCase()
-      return !n.endsWith('.zip') && !n.endsWith('.tar.gz')
-    })
-
-    const isPre = platform === 'gitee'
-        ? (item.prerelease || ['beta', 'alpha', 'pre'].some(k => String(item.tag_name).toLowerCase().includes(k)))
-        : item.prerelease
-
-    let finalTagName = item.tag_name
-    if (String(item.tag_name).toLowerCase() === 'beta' && item.name) {
-      finalTagName = item.name.replace(/^legado_app_/, '')
-    }
-
-    return {
-      tag_name: finalTagName,
-      prerelease: isPre,
-      published_at: platform === 'gitee' ? item.created_at : item.published_at,
-      body: renderMarkdown(item.body || ''),
-      html_url: platform === 'gitee' ? `https://gitee.com/${item.author?.login}/${item.name?.replace('legado_app_', '')}/releases` : item.html_url,
-      assets: filteredAssets.map(a => ({
-        id: platform === 'gitee' ? a.browser_download_url : a.id,
-        name: a.name,
-        browser_download_url: a.browser_download_url,
-        size: platform === 'gitee' ? null : a.size,
-      })),
-    }
-  })
-}
-
 const getTargetRelease = (releases, item) => {
   if (!releases || !releases.length) return null
   return item.prerelease ? releases[0] : (releases.find(r => !r.prerelease) || releases[0])
@@ -131,7 +81,7 @@ const fetchFrontmatterRelease = async () => {
   try {
     const res = await fetch(meta.apiUrl)
     if (res.ok) {
-      localRelease.value = getTargetRelease(transformReleases(await res.json(), meta.platform), item)
+      localRelease.value = getTargetRelease(transformReleases(await res.json(), meta.platform, meta.webUrl), item)
     }
   } catch (e) {
     console.error(e)

--- a/doc/.vitepress/theme/components/DownloadList.vue
+++ b/doc/.vitepress/theme/components/DownloadList.vue
@@ -37,7 +37,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { useData } from 'vitepress'
 import DownloadCard from './DownloadCard.vue'
-import { renderMarkdown } from '../utils/renderMarkdown'
+import { resolveRepoMeta, transformReleases } from '../utils/releases'
 
 const { frontmatter } = useData()
 
@@ -65,65 +65,6 @@ const releaseMap = ref({}) // { repoKey: Release[] }
 const loadingMap = ref({}) // { repoKey: boolean }
 
 const getRepoKey = (item) => item?.link || item?.github || ''
-
-// ---------- 格式化 API 数据 ----------
-const transformReleases = (rawData, platform) => {
-  if (!Array.isArray(rawData)) return []
-
-  const releases = platform === 'gitee' ? [...rawData].reverse() : rawData
-
-  return releases.map(item => {
-    const assets = (item.assets || [])
-        .filter(asset => {
-          const assetName = (asset.name || '').toLowerCase()
-          return !assetName.endsWith('.zip') && !assetName.endsWith('.tar.gz')
-        })
-        .map(asset => ({
-          id: platform === 'gitee' ? asset.browser_download_url : asset.id,
-          name: asset.name,
-          browser_download_url: asset.browser_download_url,
-          size: platform === 'gitee' ? null : asset.size,
-        }))
-
-    const isPrerelease = platform === 'gitee'
-        ? item.prerelease || ['beta', 'alpha', 'pre'].some(keyword => String(item.tag_name).toLowerCase().includes(keyword))
-        : item.prerelease
-
-    const tagName = String(item.tag_name).toLowerCase() === 'beta' && item.name
-        ? item.name.replace(/^legado_app_/, '')
-        : item.tag_name
-
-    return {
-      tag_name: tagName,
-      prerelease: isPrerelease,
-      published_at: platform === 'gitee' ? item.created_at : item.published_at,
-      body: renderMarkdown(item.body || ''),
-      html_url: platform === 'gitee'
-          ? `https://gitee.com/${item.author?.login}/${item.name?.replace('legado_app_', '')}/releases`
-          : item.html_url,
-      assets,
-    }
-  })
-}
-
-// ---------- 解析仓库元信息 ----------
-const resolveRepoMeta = (url) => {
-  if (!url) return null
-
-  const trimmedUrl = url.trim()
-
-  if (trimmedUrl.includes('gitee.com/')) {
-    const path = trimmedUrl.split('gitee.com/')[1].replace(/\/releases\/?$/, '').replace(/\/$/, '')
-    return { platform: 'gitee', apiUrl: `https://gitee.com/api/v5/repos/${path}/releases` }
-  }
-
-  if (trimmedUrl.includes('github.com/')) {
-    const path = trimmedUrl.split('github.com/')[1].replace(/\/releases\/?$/, '').replace(/\/$/, '')
-    return { platform: 'github', apiUrl: `https://api.github.com/repos/${path}/releases` }
-  }
-
-  return null
-}
 
 // ---------- 下载链接转换（传递给 DownloadCard）----------
 const getDownloadUrl = (assetUrl, repoItem) => {
@@ -160,7 +101,7 @@ const fetchRepoRelease = async (repoItem) => {
   try {
     const res = await fetch(meta.apiUrl)
     if (res.ok) {
-      releaseMap.value[repoKey] = transformReleases(await res.json(), meta.platform)
+      releaseMap.value[repoKey] = transformReleases(await res.json(), meta.platform, meta.webUrl)
     }
   } catch (error) {
     console.error(`[DownloadList] 拉取失败: ${repoKey}`, error)

--- a/doc/.vitepress/theme/utils/releases.ts
+++ b/doc/.vitepress/theme/utils/releases.ts
@@ -1,0 +1,82 @@
+import { renderMarkdown } from './renderMarkdown'
+
+const stripReleasePath = (path: string) => path
+    .replace(/\/releases(?:\/.*)?$/, '')
+    .replace(/\/$/, '')
+
+const normalizeRepoWebUrl = (repoPath: string, platform: 'gitee' | 'github') => {
+    const host = platform === 'gitee' ? 'gitee.com' : 'github.com'
+    return `https://${host}/${repoPath}`
+}
+
+export const resolveRepoMeta = (urlField?: string | null) => {
+    if (!urlField) return null
+
+    const url = urlField.trim()
+
+    if (url.includes('gitee.com/')) {
+        const path = stripReleasePath(url.split('gitee.com/')[1])
+        return {
+            platform: 'gitee' as const,
+            apiUrl: `https://gitee.com/api/v5/repos/${path}/releases`,
+            webUrl: normalizeRepoWebUrl(path, 'gitee'),
+        }
+    }
+
+    if (url.includes('github.com/')) {
+        const path = stripReleasePath(url.split('github.com/')[1])
+        return {
+            platform: 'github' as const,
+            apiUrl: `https://api.github.com/repos/${path}/releases`,
+            webUrl: normalizeRepoWebUrl(path, 'github'),
+        }
+    }
+
+    return null
+}
+
+const getGiteeReleaseUrl = (repoWebUrl: string | undefined, tagName: string, item: any) => {
+    if (repoWebUrl && tagName) {
+        return `${repoWebUrl}/releases/tag/${encodeURIComponent(tagName)}`
+    }
+
+    return item.html_url || item.url || ''
+}
+
+export const transformReleases = (rawData: any, platform: 'gitee' | 'github', repoWebUrl?: string) => {
+    if (!Array.isArray(rawData)) return []
+
+    const normalizedRawData = platform === 'gitee' ? [...rawData].reverse() : rawData
+
+    return normalizedRawData.map(item => {
+        const rawAssets = item.assets || []
+        const filteredAssets = rawAssets.filter((asset: any) => {
+            const assetName = (asset.name || '').toLowerCase()
+            return !assetName.endsWith('.zip') && !assetName.endsWith('.tar.gz')
+        })
+
+        const isPrerelease = platform === 'gitee'
+            ? (item.prerelease || ['beta', 'alpha', 'pre'].some(keyword => String(item.tag_name).toLowerCase().includes(keyword)))
+            : item.prerelease
+
+        const tagName = String(item.tag_name).toLowerCase() === 'beta' && item.name
+            ? item.name.replace(/^legado_app_/, '')
+            : item.tag_name
+
+        return {
+            tag_name: tagName,
+            prerelease: isPrerelease,
+            published_at: platform === 'gitee' ? item.created_at : item.published_at,
+            body: renderMarkdown(item.body || ''),
+            html_url: platform === 'gitee'
+                ? getGiteeReleaseUrl(repoWebUrl, tagName, item)
+                : item.html_url,
+            assets: filteredAssets.map((asset: any) => ({
+                id: platform === 'gitee' ? asset.browser_download_url : asset.id,
+                name: asset.name,
+                browser_download_url: asset.browser_download_url,
+                size: platform === 'gitee' ? null : asset.size,
+            })),
+        }
+    })
+}


### PR DESCRIPTION
### Motivation
- Gitee release detail links were being constructed incorrectly from API response fields, causing frontend links like `/releases` instead of the `/releases/tag/<tag>` detail URL. 
- `transformReleases` logic was duplicated between `DownloadList` and `DownloadCard`, causing inconsistent behavior when parent components inject `release` vs when child components fetch frontmatter releases.

### Description
- Add a shared utility `doc/.vitepress/theme/utils/releases.ts` exposing `resolveRepoMeta` and `transformReleases` to centralize repo meta parsing and release normalization. 
- Change `transformReleases` signature to accept optional `repoWebUrl` and, for Gitee, build `html_url` as `https://gitee.com/<owner>/<repo>/releases/tag/<encoded-tag>` using the normalized tag name. 
- Update `doc/.vitepress/theme/components/DownloadList.vue` to import and use the shared `resolveRepoMeta`/`transformReleases` and pass `meta.webUrl` when transforming API results. 
- Update `doc/.vitepress/theme/components/DownloadCard.vue` to import the shared utils and pass `meta.webUrl` when it still needs to fetch releases locally, ensuring consistent URL generation across parent and child flows.

### Testing
- Ran `npm run docs:build` to build the docs site and verify no runtime build errors; the build completed successfully. 
- Ran a small node check with `npx tsx -e` that calls `resolveRepoMeta` + `transformReleases` for a Gitee example and validated the produced `html_url` equals `https://gitee.com/lyc486/legado/releases/tag/3.26.030717`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a094e8719e48330bdc87f0a10dc022c)