### PR TITLE
修复 VitePress 文档构建失败

### DIFF
--- a/doc/.vitepress/config.ts
+++ b/doc/.vitepress/config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
     description: "适配 开源阅读 Legado 3.0 的 Pixiv 书源",
     base: BASE,  // 项目名称
     cleanUrls: true,        // 简洁URL
+    srcExclude: ['Common*.md'], // 公共 include 片段不作为独立页面渲染
     ignoreDeadLinks: true,  // 忽略死链
     appearance: true,       // 默认主题由用户配色方案决定
     lastUpdated: true,      // 获取页面最后更新的时间戳

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "markdown-it-anchor": "^9.2.0",
     "tsx": "^4.20.6",
-    "vitepress": "^1.6.4"
+    "vitepress": "^1.6.4",
+    "vue": "^3.5.24"
   },
   "devDependencies": {
     "vitepress-markdown-timeline": "^1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.44.0)(postcss@8.5.6)(search-insights@2.17.3)
+      vue:
+        specifier: ^3.5.24
+        version: 3.5.24
     devDependencies:
       vitepress-markdown-timeline:
         specifier: ^1.2.2


### PR DESCRIPTION
### Motivation

- 修复 VitePress 构建过程中出现的 SSR 运行时报错，原因是生成的 Markdown SSR 模块需要解析 `vue` 包但项目未声明为直接依赖导致模块解析失败。 
- 防止项目内的公共 include 片段（如 `Common*.md`）被 VitePress 当作独立页面渲染，从而在片段里访问 `route.path` 等父页面变量时出现 `undefined`。

### Description

- 在 `package.json` 的 `dependencies` 中新增 `vue: "^3.5.24"` 以确保 SSR 渲染时能解析到 `vue`。 
- 同步更新 `pnpm-lock.yaml`，将 `vue@3.5.24` 写入导入器依赖部分以匹配新增的直接依赖。 
- 在 `doc/.vitepress/config.ts` 中新增 `srcExclude: ['Common*.md']` 配置以阻止公共 include 片段被单独渲染为页面。 

### Testing

- 执行了 `pnpm install --offline --frozen-lockfile`，依赖安装并更新锁文件成功。 
- 执行了 `pnpm docs:build`，构建过程最终通过（之前在未添加 `vue` 与 `srcExclude` 前会报 `Cannot find package 'vue'` 与 `Cannot read properties of undefined (reading 'path')` 错误）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29e8e8b8f88330aa71b35463df495a)