### PR TITLE
docs: use `page.relativePath` for conditional includes, exclude Common*.md from rendering, add `vue` dependency

### DIFF
--- a/doc/.vitepress/config.ts
+++ b/doc/.vitepress/config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
     description: "适配 开源阅读 Legado 3.0 的 Pixiv 书源",
     base: BASE,  // 项目名称
     cleanUrls: true,        // 简洁URL
+    srcExclude: ['Common*.md'], // 公共 include 片段不作为独立页面渲染
     ignoreDeadLinks: true,  // 忽略死链
     appearance: true,       // 默认主题由用户配色方案决定
     lastUpdated: true,      // 获取页面最后更新的时间戳

--- a/doc/BetterExperience.md
+++ b/doc/BetterExperience.md
@@ -28,9 +28,11 @@ head:
 ---
 
 <script setup>
-import { useRoute, useRouter } from "vitepress";
-const route = useRoute();
-route.path = route.path.replace("/", "");
+import { computed } from "vue";
+import { useData } from "vitepress";
+
+const { page } = useData();
+const pagePath = computed(() => page.value.relativePath.replace(/\.md$/, ""));
 </script>
 
 

--- a/doc/CommonImport.md
+++ b/doc/CommonImport.md
@@ -1,6 +1,6 @@
 
 
-<div v-if="route.path === 'Pixiv' || route.path === 'BetterExperience'">
+<div v-if="pagePath === 'Pixiv' || pagePath === 'BetterExperience'">
 
 > [!IMPORTANT]
 >
@@ -14,7 +14,7 @@
 </div>
 
 
-<div v-if="route.path === 'Linpx'">
+<div v-if="pagePath === 'Linpx'">
 
 > [!IMPORTANT]
 >
@@ -28,7 +28,7 @@
 </div>
 
 
-<div v-if="route.path === 'FurryNovel'">
+<div v-if="pagePath === 'FurryNovel'">
 
 > [!IMPORTANT]
 >

--- a/doc/CommonImportMethod.md
+++ b/doc/CommonImportMethod.md
@@ -6,7 +6,7 @@
 >
 >　**点击链接，一键导入 书源、订阅源**
 
-<div v-if="route.path === 'QuickStart'">
+<div v-if="pagePath === 'QuickStart'">
 
 | 源名称    | jsDelivr | Github |
 |--------| -------- | ------ |
@@ -16,7 +16,7 @@
 </div>
 
 
-<div v-if="route.path.startsWith('Import')">
+<div v-if="pagePath.startsWith('Import')">
 
 | 源名称    | jsDelivr | Github |
 |--------| -------- | ------ |
@@ -39,7 +39,7 @@
 ![img](./pic/InportBookSourcePixiv.png)
 </details>
 
-<div v-if="route.path.startsWith('Import')">
+<div v-if="pagePath.startsWith('Import')">
 <details><summary><strong> ⚙️ 一键导入　网站设置 </strong></summary>
   
   > [!NOTE]
@@ -69,7 +69,7 @@
 > 
 >　**订阅 - 规则订阅 - 添加 - 复制链接、粘贴 - 添加订阅**
 
-<div v-if="route.path === 'QuickStart'">
+<div v-if="pagePath === 'QuickStart'">
 
 | 源名称 | jsDelivr | Github |
 | ----- | -------- | ------ |
@@ -79,7 +79,7 @@
 </div>
 
 
-<div v-if="route.path.startsWith('Import')">
+<div v-if="pagePath.startsWith('Import')">
 
 | 源名称 | jsDelivr | Github |
 | ----- | -------- | ------ |
@@ -112,7 +112,7 @@
 </details>
 
 
-<div v-if="route.path.startsWith('ImportBookSource')">
+<div v-if="pagePath.startsWith('ImportBookSource')">
 
 ### 🌐 C.网络导入 {#InternetBookSource}
 <details><summary><strong> 🌐 网络导入　详细操作</strong></summary>
@@ -136,7 +136,7 @@
 </div>
 
 
-<div v-if="route.path.startsWith('ImportRssSource')">
+<div v-if="pagePath.startsWith('ImportRssSource')">
 
 ### 🌐 C.网络导入 {#InternetRssSource}
 <details><summary><strong> 🌐 网络导入　详细操作</strong></summary>
@@ -162,7 +162,7 @@
 </div>
 
 
-<div v-if="route.path.startsWith('Import')">
+<div v-if="pagePath.startsWith('Import')">
 
 ### 📑 D.文件导入 {#File}
 <details><summary><strong> 📄 文件导入　详细操作</strong></summary>

--- a/doc/CommonPixivFunction.md
+++ b/doc/CommonPixivFunction.md
@@ -146,7 +146,7 @@
 > **2️⃣ 文本框输入作者ID，点击按钮【🚫 屏蔽作者】，屏蔽指定作者**
 
 
-<div v-if="route.path === 'Pixiv'">
+<div v-if="pagePath === 'Pixiv'">
 
 ### 🚫 屏蔽标签 & 屏蔽描述 {#BlockWords}
 > [!NOTE]

--- a/doc/CommonSuffix.md
+++ b/doc/CommonSuffix.md
@@ -1,5 +1,5 @@
 
-<div v-if="route.path === 'BetterExperience' || route.path === 'QuickStart'">
+<div v-if="pagePath === 'BetterExperience' || pagePath === 'QuickStart'">
 
 ## 📖 畅享阅读 {#EnjoyReading}
 - 🔍 [搜索小说](Pixiv.md#SearchNovel)：书架页面，搜索小说，添加小说到书架

--- a/doc/FurryNovel.md
+++ b/doc/FurryNovel.md
@@ -35,9 +35,11 @@ repos:
 ---
 
 <script setup>
-import { useRoute, useRouter } from "vitepress";
-const route = useRoute();
-route.path = route.path.replace("/", "");
+import { computed } from "vue";
+import { useData } from "vitepress";
+
+const { page } = useData();
+const pagePath = computed(() => page.value.relativePath.replace(/\.md$/, ""));
 </script>
 
 

--- a/doc/ImportBookSource.md
+++ b/doc/ImportBookSource.md
@@ -25,9 +25,11 @@ head:
 ---
 
 <script setup>
-import { useRoute, useRouter } from "vitepress";
-const route = useRoute();
-route.path = route.path.replace("/", "");
+import { computed } from "vue";
+import { useData } from "vitepress";
+
+const { page } = useData();
+const pagePath = computed(() => page.value.relativePath.replace(/\.md$/, ""));
 </script>
 
 

--- a/doc/ImportRssSource.md
+++ b/doc/ImportRssSource.md
@@ -25,9 +25,11 @@ head:
 ---
 
 <script setup>
-import { useRoute, useRouter } from "vitepress";
-const route = useRoute();
-route.path = route.path.replace("/", "");
+import { computed } from "vue";
+import { useData } from "vitepress";
+
+const { page } = useData();
+const pagePath = computed(() => page.value.relativePath.replace(/\.md$/, ""));
 </script>
 
 

--- a/doc/Linpx.md
+++ b/doc/Linpx.md
@@ -35,9 +35,11 @@ repos:
 ---
 
 <script setup>
-import { useRoute, useRouter } from "vitepress";
-const route = useRoute();
-route.path = route.path.replace("/", "");
+import { computed } from "vue";
+import { useData } from "vitepress";
+
+const { page } = useData();
+const pagePath = computed(() => page.value.relativePath.replace(/\.md$/, ""));
 </script>
 
 

--- a/doc/Pixiv.md
+++ b/doc/Pixiv.md
@@ -38,9 +38,11 @@ repos:
 ---
 
 <script setup>
-import { useRoute, useRouter } from "vitepress";
-const route = useRoute();
-route.path = route.path.replace("/", "");
+import { computed } from "vue";
+import { useData } from "vitepress";
+
+const { page } = useData();
+const pagePath = computed(() => page.value.relativePath.replace(/\.md$/, ""));
 </script>
 
 

--- a/doc/QuickStart.md
+++ b/doc/QuickStart.md
@@ -28,9 +28,11 @@ head:
 ---
 
 <script setup>
-import { useRoute, useRouter } from "vitepress";
-const route = useRoute();
-route.path = route.path.replace("/", "");
+import { computed } from "vue";
+import { useData } from "vitepress";
+
+const { page } = useData();
+const pagePath = computed(() => page.value.relativePath.replace(/\.md$/, ""));
 </script>
 
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "markdown-it-anchor": "^9.2.0",
     "tsx": "^4.20.6",
-    "vitepress": "^1.6.4"
+    "vitepress": "^1.6.4",
+    "vue": "^3.5.24"
   },
   "devDependencies": {
     "vitepress-markdown-timeline": "^1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.44.0)(postcss@8.5.6)(search-insights@2.17.3)
+      vue:
+        specifier: ^3.5.24
+        version: 3.5.24
     devDependencies:
       vitepress-markdown-timeline:
         specifier: ^1.2.2


### PR DESCRIPTION
### Motivation

- Replace fragile `route.path` string manipulation with a robust page-relative path to correctly control conditional includes across VitePress pages.
- Prevent shared include fragments (matching `Common*.md`) from being rendered as standalone pages by VitePress.
- Ensure the documentation code that uses `useData` works by declaring `vue` as a dependency.

### Description

- Replaced usages of `useRoute`/`useRouter` and `route.path` in many docs with a `pagePath` computed from `useData().page.relativePath.replace(/\.md$/, "")` and added `import { computed } from 'vue'` and `import { useData } from 'vitepress'` where needed. 
- Updated multiple documentation files (`QuickStart.md`, `Pixiv.md`, `Linpx.md`, `FurryNovel.md`, `ImportBookSource.md`, `ImportRssSource.md`, `BetterExperience.md` and common fragments like `CommonImport.md`, `CommonImportMethod.md`, `CommonSuffix.md`, `CommonPixivFunction.md`) to use `pagePath` in conditional `v-if` checks.
- Added `srcExclude: ['Common*.md']` to `doc/.vitepress/config.ts` to stop common include fragments from being rendered as independent pages.
- Added `vue` dependency in `package.json` and updated `pnpm-lock.yaml` to include `vue` so the docs code can import `computed` and work in VitePress.

### Testing

- Ran the documentation build with `npm run docs:build` to validate the site builds with the updated imports and configuration, and the build completed successfully.
- Performed a local docs dev run with `npm run docs:dev` to verify the conditional fragments render correctly in the dev server, and no runtime errors were observed.
- No automated unit tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29e8e8b8f88330aa71b35463df495a)