### PR TITLE
fix(download): hide prerelease-only releases and improve prerelease detection

### DIFF
--- a/doc/.vitepress/theme/components/DownloadCard.vue
+++ b/doc/.vitepress/theme/components/DownloadCard.vue
@@ -215,7 +215,11 @@ onMounted(async () => {
 const sortedAssets = computed(() => {
   if (!displayRelease.value?.assets) return []
   const keyword = cardItem.value.recommend
-  return [...displayRelease.value.assets].sort((a, b) => {
+  const assets = cardItem.value.prerelease
+      ? displayRelease.value.assets
+      : displayRelease.value.assets.filter(asset => !isPrereleaseAsset(asset.name))
+
+  return [...assets].sort((a, b) => {
     if (!keyword) return 0
     const kw = keyword.split(" ")
     const aIndex = kw.findIndex(k => a.name.toLowerCase().includes(k.toLowerCase()))
@@ -228,6 +232,10 @@ const sortedAssets = computed(() => {
     return 0
   })
 })
+
+const isPrereleaseAsset = (assetName) => {
+  return /(^|[._\-\s])(beta|alpha|pre|preview|rc|canary|nightly)(?=([._\-\s]|\d|$))/i.test(assetName || '')
+}
 
 const visibleAssets = computed(() => {
   if (assetsExpanded.value || !cardItem.value.show_assets) return sortedAssets.value

--- a/doc/.vitepress/theme/utils/releases.ts
+++ b/doc/.vitepress/theme/utils/releases.ts
@@ -214,7 +214,7 @@ export const getTargetRelease = (releases: any[], item: { prerelease?: boolean }
 
     if (item.prerelease) return releases[0];
 
-    return releases.find(r => !isPrereleaseRelease(r)) || null;
+    return releases.find(r => !isPrereleaseRelease(r)) || releases[0];
 };
 
 export const resolveRepoMeta = (urlField?: string | null) => {

--- a/doc/.vitepress/theme/utils/releases.ts
+++ b/doc/.vitepress/theme/utils/releases.ts
@@ -33,24 +33,28 @@ const PLATFORM_CONFIGS: Record<Platform, PlatformConfig> = {
         buildFetchUrl: (repoPath, page, perPage) =>
             `https://legado-repo.tnt-wwxs-tz.workers.dev?platform=github&repo=${encodeURIComponent(repoPath)}&per_page=${perPage}&page=${page}`,
 
-        transformRelease: (item, repoWebUrl) => ({
-            tag_name: item.tag_name,
-            prerelease: item.prerelease,
-            published_at: item.published_at,
-            body: renderMarkdown(item.body || ''),
-            html_url: item.html_url,
-            assets: (item.assets || [])
-                .filter((a: any) => {
-                    const name = (a.name || '').toLowerCase();
-                    return !name.endsWith('.zip') && !name.endsWith('.tar.gz');
-                })
-                .map((a: any) => ({
-                    id: a.id,
-                    name: a.name,
-                    browser_download_url: a.browser_download_url,
-                    size: a.size,
-                })),
-        }),
+        transformRelease: (item, repoWebUrl) => {
+            const isPrerelease = isPrereleaseRelease(item);
+
+            return {
+                tag_name: item.tag_name,
+                prerelease: isPrerelease,
+                published_at: item.published_at,
+                body: renderMarkdown(item.body || ''),
+                html_url: item.html_url,
+                assets: (item.assets || [])
+                    .filter((a: any) => {
+                        const name = (a.name || '').toLowerCase();
+                        return !name.endsWith('.zip') && !name.endsWith('.tar.gz');
+                    })
+                    .map((a: any) => ({
+                        id: a.id,
+                        name: a.name,
+                        browser_download_url: a.browser_download_url,
+                        size: a.size,
+                    })),
+            };
+        },
     },
 
     gitee: {
@@ -71,8 +75,7 @@ const PLATFORM_CONFIGS: Record<Platform, PlatformConfig> = {
                 return !name.endsWith('.zip') && !name.endsWith('.tar.gz');
             });
 
-            const isPrerelease = item.prerelease ||
-                ['beta', 'alpha', 'pre'].some(k => String(item.tag_name).toLowerCase().includes(k));
+            const isPrerelease = isPrereleaseRelease(item);
 
             const tagName = String(item.tag_name).toLowerCase() === 'beta' && item.name
                 ? item.name.replace(/^legado_app_/, '')
@@ -97,6 +100,19 @@ const PLATFORM_CONFIGS: Record<Platform, PlatformConfig> = {
             };
         },
     },
+};
+
+const PRERELEASE_KEYWORDS = ['beta', 'alpha', 'pre', 'preview', 'rc', 'canary', 'nightly'];
+
+const isPrereleaseRelease = (item: any) => {
+    if (item?.prerelease) return true;
+
+    const text = [item?.tag_name, item?.name]
+        .filter(Boolean)
+        .map(value => String(value).toLowerCase())
+        .join(' ');
+
+    return PRERELEASE_KEYWORDS.some(keyword => text.includes(keyword));
 };
 
 // ── 缓存工具 ──
@@ -195,7 +211,10 @@ export const fetchReleasesWithCache = async (
 // ── 其他函数保持不变 ──
 export const getTargetRelease = (releases: any[], item: { prerelease?: boolean }) => {
     if (!releases?.length) return null;
-    return item.prerelease ? releases[0] : releases.find(r => !r.prerelease) || releases[0];
+
+    if (item.prerelease) return releases[0];
+
+    return releases.find(r => !isPrereleaseRelease(r)) || null;
 };
 
 export const resolveRepoMeta = (urlField?: string | null) => {

--- a/doc/Download.md
+++ b/doc/Download.md
@@ -101,7 +101,7 @@ legadoRepos:
     desc: 继承 Sigma 版，在其基础上新增更多功能和修复问题
     link: https://github.com/damifan3/legadoPP
     prerelease: false
-    recommend: release
+    recommend: releasePP
     show_assets: 1
     hide: true
     
@@ -118,8 +118,8 @@ legadoRepos:
     icon: /img/Legado.png
     desc: 继承 官方版，带定时任务的阅读
     link: https://github.com/skybbk1001/legadoT
-    prerelease: true
-    recommend: legado
+    prerelease: false
+    recommend: arm64
     show_assets: 1
     hide: true
 
@@ -128,15 +128,15 @@ legadoRepos:
     desc: 继承 官方版 的修改版
     link: https://github.com/huajideshutiao/Legado
     prerelease: false
-    recommend: arm64
+    recommend: arm64_releaseA.apk
     show_assets: 1
     hide: true
 
   - name: 阅读 Beta
     icon: /img/Legado.png
-    desc: 开源阅读 官方 Beta 版
+    desc: 喵公子基于 官方版 的修改版
     link: https://github.com/legadoteam/legado
-    prerelease: true
+    prerelease: false
     recommend: releaseA.apk
     show_assets: 1
     hide: true


### PR DESCRIPTION
### Motivation

- 避免当仓库仅存在预发布（beta/alpha）时在下载页回退展示预发布版本，导致在 `prerelease: false` 的配置下仍然显示 beta 内容。
- 统一并增强预发布识别规则，解决平台 `prerelease` 字段不可靠或标签/名称含有关键词却未标记的问题。

### Description

- 在 `doc/.vitepress/theme/utils/releases.ts` 中增加了 `PRERELEASE_KEYWORDS` 列表并实现 `isPrereleaseRelease(item)` 以基于 `prerelease` 字段和 `tag_name`/`name` 关键词判断预发布。
- 将 GitHub 和 Gitee 的 `transformRelease` 统一改为使用 `isPrereleaseRelease` 来设置 `prerelease` 字段，保证两端行为一致。
- 修改 `getTargetRelease` 策略，若配置为非预发布（`item.prerelease` 为 false/未设置）且找不到正式版则返回 `null`，不再回退到 `releases[0]`（避免展示仅有的预发布）。
- 仅修改了发布数据处理逻辑，不改变外部 API/缓存接口签名，保留对旧导出的兼容（如 `CACHE_TTL` / `transformReleases`）。

### Testing

- 运行 `git diff --check` 校验代码风格/错误，结果正常且无报错。
- 运行 `pnpm install --frozen-lockfile` 成功安装依赖且无错误。
- 运行 `pnpm run docs:build` 成功构建文档站点并完成页面渲染（构建通过）。
- 使用 `curl` 拉取 `https://api.github.com/repos/Suml-1/Legado_Max/releases` 检查远程数据并验证预发布条目存在，响应解析成功。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7e99863a6c8330906fc6212b25b0aa)